### PR TITLE
Fix deprecation warning after upgrade to Rails 7.1

### DIFF
--- a/lib/authority.rb
+++ b/lib/authority.rb
@@ -41,7 +41,7 @@ module Authority
 
   def self.action_authorized?(action, resource, user, options = {})
     raise MissingUser if user.nil?
-    resource_and_maybe_options = [resource, options].tap {|args| args.pop if args.last == {}}
+    resource_and_maybe_options = [resource, options].tap {|args| args.pop if args.last.empty?}
     user.send("can_#{action}?", *resource_and_maybe_options)
   end
 

--- a/lib/authority/user_abilities.rb
+++ b/lib/authority/user_abilities.rb
@@ -11,7 +11,7 @@ module Authority
     Authority.verbs.each do |verb|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def can_#{verb}?(resource, options = {})
-          self_and_maybe_options = [self, options].tap {|args| args.pop if args.last == {}}
+          self_and_maybe_options = [self, options].tap {|args| args.pop if args.last.empty?}
           resource.#{Authority.abilities[verb]}_by?(*self_and_maybe_options)
         end
       RUBY


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DSP-583
The code in authority was incorrectly comparing an instance of ActionController::Parameters with a hash but this has only just started raising a deprecation warning. These changes fix the incorrect comparison